### PR TITLE
Fix Bird Of Paradise mob name for UltraScouter

### DIFF
--- a/source/ACT.Hojoring.Common/resources/MobList.en-US.txt
+++ b/source/ACT.Hojoring.Common/resources/MobList.en-US.txt
@@ -68,7 +68,7 @@ Gandarewa                       S
 Senmurv                         S
 "The Pale Rider"                S
 Leucrotta                       S
-"Bird of Paradise"              S
+"Bird Of Paradise"              S
 "Kaiser Behemoth"               S
 
 ## Rank A

--- a/source/ACT.Hojoring.Common/resources/MobList.en-US.txt
+++ b/source/ACT.Hojoring.Common/resources/MobList.en-US.txt
@@ -79,7 +79,7 @@ Sisiutl                         A
 Bune                            A
 Agathos                         A
 Pylraster                       A
-"Lord of the Wyverns"           A
+"Lord Of The Wyverns"           A
 "Slipkinx Steeljoints"          A
 Stolas                          A
 Campacti                        A


### PR DESCRIPTION
Bird of Paradise did not register for me with the lower "of" with this set of versions: 

```
FFXIV_ACT_Plugin v1.7.2.8
FFXIV_MemoryReader v1.4.13.0
ACT.Hojoring v6.3.4
ACT.SpecialSpellTimer v2.11.13
ACT.UltraScouter v1.8.2
ACT.TTSYukkuri v4.2.2
```